### PR TITLE
Let's use /usr/bin/env for better portability

### DIFF
--- a/SOURCES/opt/check50/bin/check50.js
+++ b/SOURCES/opt/check50/bin/check50.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 //
 // This is CS50 Check.
 //


### PR DESCRIPTION
Hi,
/bin/env does not exist on some systems, like OSX. /usr/bin/env is recommended for better portability.

Thanks,
Arcadie
